### PR TITLE
Update pkistudiojs to v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1355,8 +1355,8 @@
       }
     },
     "node_modules/pkistudiojs": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/pkistudio/pkistudiojs.git#64be5335c63799320db981afbfeef79b0f328623",
+      "version": "0.2.1",
+      "resolved": "git+ssh://git@github.com/pkistudio/pkistudiojs.git#568e7e17633cc351a750dec8c8c267b2e794bb62",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {


### PR DESCRIPTION
Updates the locked PkiStudioJS dependency from v0.2.0 to v0.2.1 and verifies that the MCP server's ASN.1 tool wrappers remain compatible.

Summary:
- Refreshed `package-lock.json` so `pkistudiojs` resolves to v0.2.1 (`568e7e17633cc351a750dec8c8c267b2e794bb62`).
- Reviewed the upstream v0.2.0...v0.2.1 Core API diff; the MCP-used Core API surface is unchanged, with only the internal Core `VERSION` string changing.
- Left the `@pkistudio/pkistudiomcp` package version unchanged because the final release version still needs confirmation before npm publication/tagging.

Verification:
- `npm run check`
- `npm pack --dry-run`
- Manual wrapper check with `3003020101` covering parse, summarize, describe, and OID resolution

Fixes #5