### PR TITLE
Prepare v0.0.6 npm release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,48 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version to publish, for example 0.0.6"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify package version
+        run: |
+          actual_version="$(node -p "require('./package.json').version")"
+          if [[ "$actual_version" != "${{ inputs.version }}" ]]; then
+            echo "package.json version $actual_version does not match workflow input ${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Run checks
+        run: npm run check
+
+      - name: Preview package contents
+        run: npm pack --dry-run
+
+      - name: Publish package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 Core API tools.",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const asn1InputSchema = {
 
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.0.5",
+  version: "0.0.6",
 });
 
 server.registerTool(


### PR DESCRIPTION
Prepares the v0.0.6 release and adds a manual GitHub Actions workflow for npm publication using the repository `NPM_TOKEN` secret.

Summary:
- Bumps `@pkistudio/pkistudiomcp` package metadata to 0.0.6.
- Updates MCP server metadata to 0.0.6.
- Adds `workflow_dispatch` npm publish workflow with version verification, `npm run check`, `npm pack --dry-run`, and `npm publish --access public`.

Verification:
- YAML parse check with Ruby
- `npm run check`
- `npm pack --dry-run`
- Manual wrapper check with `3003020101` covering parse, summarize, describe, and OID resolution

Refs #5