### PR TITLE
Update pkistudiojs to v0.2.2 for 0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The package currently depends on PkiStudioJS directly from GitHub:
 ```json
 {
 	"dependencies": {
-		"pkistudiojs": "github:pkistudio/pkistudiojs"
+		"pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.2"
 	}
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "pkistudiojs": "github:pkistudio/pkistudiojs",
+        "pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.2",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -1355,8 +1355,8 @@
       }
     },
     "node_modules/pkistudiojs": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/pkistudio/pkistudiojs.git#568e7e17633cc351a750dec8c8c267b2e794bb62",
+      "version": "0.2.2",
+      "resolved": "git+ssh://git@github.com/pkistudio/pkistudiojs.git#9e3dac73780daa65f8351563a89e2d9c4874b79d",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 Core API tools.",
   "type": "module",
   "repository": {
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "pkistudiojs": "github:pkistudio/pkistudiojs",
+    "pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.2",
     "zod": "^4.4.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const asn1InputSchema = {
 
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.0.6",
+  version: "0.0.7",
 });
 
 server.registerTool(


### PR DESCRIPTION
## Summary
- Bump @pkistudio/pkistudiomcp to 0.0.7.
- Pin pkistudiojs to the GitHub v0.2.2 release tag.
- Align MCP server metadata and README dependency example with the release.

## Verification
- npm run check
- npm pack --dry-run

Fixes #10