### PR TITLE
Add PkiStudioJS core helper tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The package currently depends on PkiStudioJS directly from GitHub:
 ```json
 {
 	"dependencies": {
-		"pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.2"
+		"pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.5"
 	}
 }
 ```
@@ -17,6 +17,11 @@ The package currently depends on PkiStudioJS directly from GitHub:
 - `parse_asn1`: Parse DER, BER, PEM, HEX, base64, or headerless PEM input and return a JSON ASN.1 tree.
 - `summarize_asn1`: Return a compact summary with tag counts, discovered OIDs, and top-level nodes.
 - `describe_node`: Describe one parsed ASN.1 node by node id.
+- `extract_asn1_node`: Extract one parsed ASN.1 node and its subtree as DER bytes.
+- `normalize_asn1_input`: Decode supported ASN.1 input and return round-trip re-encoded bytes.
+- `asn1_node_value`: Return a node's decoded display value and raw value bytes.
+- `encode_oid`: Encode an OID string into ASN.1 OBJECT IDENTIFIER value bytes.
+- `decode_oid_value`: Decode ASN.1 OBJECT IDENTIFIER value bytes into dotted OID text.
 - `resolve_oid`: Resolve an OID using the OID names bundled with PkiStudioJS.
 
 Input is string-based. Use `format: "auto"` to let PkiStudioJS detect the input, or provide one of `der`, `ber`, `pem`, `base64`, `headerless-pem`, or `hex`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.2",
+        "pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.5",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -1355,8 +1355,8 @@
       }
     },
     "node_modules/pkistudiojs": {
-      "version": "0.2.2",
-      "resolved": "git+ssh://git@github.com/pkistudio/pkistudiojs.git#9e3dac73780daa65f8351563a89e2d9c4874b79d",
+      "version": "0.2.5",
+      "resolved": "git+ssh://git@github.com/pkistudio/pkistudiojs.git#72354fbc715a826884dd315bd914d479ec1790a6",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 Core API tools.",
   "type": "module",
   "repository": {
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.2",
+    "pkistudiojs": "github:pkistudio/pkistudiojs#v0.2.5",
     "zod": "^4.4.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import {
+  decodeOidValue,
   describeNode,
+  encodeOidValue,
+  extractAsn1Node,
+  getAsn1NodeValue,
   loadOidNames,
+  normalizeAsn1Input,
   parseAsn1,
   resolveOid,
   summarizeAsn1,
@@ -25,9 +30,11 @@ const asn1InputSchema = {
   hexPreviewLength: z.number().int().min(1).max(4096).optional().describe("Maximum hex preview length."),
 };
 
+const outputEncodingSchema = z.enum(["hex", "base64"]).default("hex").describe("Output encoding for DER or value bytes.");
+
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.0.7",
+  version: "0.0.8",
 });
 
 server.registerTool(
@@ -69,6 +76,75 @@ server.registerTool(
     },
   },
   async (input) => jsonToolResult(describeNode(input)),
+);
+
+server.registerTool(
+  "extract_asn1_node",
+  {
+    title: "Extract ASN.1 Node",
+    description: "Extract a parsed ASN.1 node and its subtree by node id as DER bytes.",
+    inputSchema: {
+      data: asn1InputSchema.data,
+      nodeId: z.string().min(1).describe("Node id from parse_asn1 output."),
+      format: inputFormatSchema,
+      encoding: outputEncodingSchema,
+    },
+  },
+  async (input) => jsonToolResult(extractAsn1Node(input)),
+);
+
+server.registerTool(
+  "normalize_asn1_input",
+  {
+    title: "Normalize ASN.1 Input",
+    description: "Decode DER, BER, PEM, HEX, or base64 input and return round-trip re-encoded ASN.1 bytes.",
+    inputSchema: {
+      data: asn1InputSchema.data,
+      format: inputFormatSchema,
+      encoding: outputEncodingSchema,
+    },
+  },
+  async (input) => jsonToolResult(normalizeAsn1Input(input)),
+);
+
+server.registerTool(
+  "asn1_node_value",
+  {
+    title: "ASN.1 Node Value",
+    description: "Return the decoded display value and raw value bytes for one parsed ASN.1 node.",
+    inputSchema: {
+      data: asn1InputSchema.data,
+      nodeId: z.string().min(1).describe("Node id from parse_asn1 output."),
+      format: inputFormatSchema,
+      encoding: outputEncodingSchema,
+    },
+  },
+  async (input) => jsonToolResult(getAsn1NodeValue(input)),
+);
+
+server.registerTool(
+  "encode_oid",
+  {
+    title: "Encode OID",
+    description: "Encode an object identifier string into ASN.1 OBJECT IDENTIFIER value bytes.",
+    inputSchema: {
+      oid: z.string().regex(/^\d+(?:\.\d+)+$/).describe("Object identifier, for example 1.2.840.113549.1.1.11."),
+    },
+  },
+  async ({ oid }) => jsonToolResult(encodeOidValue(oid)),
+);
+
+server.registerTool(
+  "decode_oid_value",
+  {
+    title: "Decode OID Value",
+    description: "Decode ASN.1 OBJECT IDENTIFIER value bytes into dotted object identifier text.",
+    inputSchema: {
+      value: z.string().min(1).describe("ASN.1 OBJECT IDENTIFIER value bytes as HEX or base64."),
+      encoding: outputEncodingSchema,
+    },
+  },
+  async (input) => jsonToolResult(decodeOidValue(input)),
 );
 
 server.registerTool(

--- a/src/pkistudio.ts
+++ b/src/pkistudio.ts
@@ -43,13 +43,27 @@ type ParsedDocument = {
 };
 
 type PkiStudioCore = {
+  base64ToBytes(base64: string): Uint8Array;
+  bytesToBase64(bytes: Uint8Array): string;
+  decodeInput(input: string | Uint8Array, options?: Pick<ParseOptions, "format">): { bytes: Uint8Array; format: string };
+  decodeOid(bytes: Uint8Array): string;
+  describeValue(node: unknown): string;
+  encodeNodes(nodes: unknown[]): Uint8Array;
+  encodeOid(oid: string): Uint8Array;
   parseInput(input: string | Uint8Array, options?: ParseOptions): ParsedDocument;
   parseAsn1(input: string | Uint8Array, options?: ParseOptions): { format: string; length: number; nodes: SerializedNode[] };
   serializeNode(node: unknown, options?: ParseOptions): SerializedNode;
   serializeTree(nodes: unknown[], options?: ParseOptions): SerializedNode[];
   findNodeById(nodes: unknown[], nodeId: string): unknown | null;
+  getNodeBytes(nodes: unknown[], nodeId: string): Uint8Array;
+  getNodeValueBytes(node: unknown): Uint8Array;
+  getTagName(node: unknown): string;
+  hexToBytes(text: string, options?: { allowEmpty?: boolean }): Uint8Array;
   resolveOid(oid: string, oidNames?: Record<string, string>): string;
+  toLowerHexString(bytes: Uint8Array): string;
 };
+
+type OutputEncoding = "hex" | "base64";
 
 type Asn1Input = ParseOptions & {
   data: string;
@@ -64,6 +78,24 @@ type SummaryInput = {
 type DescribeNodeInput = ParseOptions & {
   data: string;
   nodeId: string;
+};
+
+type NodeInput = {
+  data: string;
+  nodeId: string;
+  format?: InputFormat;
+  encoding?: OutputEncoding;
+};
+
+type NormalizeInput = {
+  data: string;
+  format?: InputFormat;
+  encoding?: OutputEncoding;
+};
+
+type DecodeOidInput = {
+  value: string;
+  encoding?: OutputEncoding;
 };
 
 const require = createRequire(import.meta.url);
@@ -123,6 +155,75 @@ export function describeNode(input: DescribeNodeInput) {
   return pkistudio.serializeNode(node, withOidNames(input));
 }
 
+export function extractAsn1Node(input: NodeInput) {
+  const document = pkistudio.parseInput(input.data, { format: input.format, oidNames: loadOidNames() });
+  const node = pkistudio.findNodeById(document.nodes, input.nodeId);
+  if (!node) {
+    throw new Error(`ASN.1 node not found: ${input.nodeId}`);
+  }
+
+  const bytes = pkistudio.getNodeBytes(document.nodes, input.nodeId);
+  return {
+    nodeId: input.nodeId,
+    sourceFormat: document.format,
+    length: bytes.length,
+    encoding: input.encoding ?? "hex",
+    data: encodeBytes(bytes, input.encoding),
+    node: pkistudio.serializeNode(node, { maxDepth: 1, includeHexPreview: true, oidNames: loadOidNames() }),
+  };
+}
+
+export function normalizeAsn1Input(input: NormalizeInput) {
+  const document = pkistudio.parseInput(input.data, { format: input.format, oidNames: loadOidNames() });
+  const encodedBytes = pkistudio.encodeNodes(document.nodes);
+  return {
+    sourceFormat: document.format,
+    length: document.bytes.length,
+    canonicalLength: encodedBytes.length,
+    roundTrip: bytesEqual(document.bytes, encodedBytes),
+    encoding: input.encoding ?? "hex",
+    data: encodeBytes(encodedBytes, input.encoding),
+  };
+}
+
+export function getAsn1NodeValue(input: NodeInput) {
+  const document = pkistudio.parseInput(input.data, { format: input.format, oidNames: loadOidNames() });
+  const node = pkistudio.findNodeById(document.nodes, input.nodeId);
+  if (!node) {
+    throw new Error(`ASN.1 node not found: ${input.nodeId}`);
+  }
+
+  const valueBytes = pkistudio.getNodeValueBytes(node);
+  return {
+    nodeId: input.nodeId,
+    sourceFormat: document.format,
+    tagName: pkistudio.getTagName(node),
+    value: pkistudio.describeValue(node),
+    valueLength: valueBytes.length,
+    encoding: input.encoding ?? "hex",
+    valueBytes: encodeBytes(valueBytes, input.encoding),
+  };
+}
+
+export function encodeOidValue(oid: string) {
+  const bytes = pkistudio.encodeOid(oid);
+  return {
+    oid,
+    valueHex: encodeBytes(bytes, "hex"),
+    valueBase64: encodeBytes(bytes, "base64"),
+  };
+}
+
+export function decodeOidValue(input: DecodeOidInput) {
+  const bytes = decodeBytes(input.value, input.encoding ?? "hex");
+  const oid = pkistudio.decodeOid(bytes);
+  return {
+    oid,
+    valueHex: encodeBytes(bytes, "hex"),
+    name: resolveOid(oid).name,
+  };
+}
+
 export function resolveOid(oid: string) {
   const name = pkistudio.resolveOid(oid, loadOidNames());
   return {
@@ -154,4 +255,22 @@ function countBy(values: string[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const value of values) counts[value] = (counts[value] || 0) + 1;
   return counts;
+}
+
+function encodeBytes(bytes: Uint8Array, encoding: OutputEncoding = "hex"): string {
+  if (encoding === "base64") return pkistudio.bytesToBase64(bytes);
+  return pkistudio.toLowerHexString(bytes);
+}
+
+function decodeBytes(value: string, encoding: OutputEncoding): Uint8Array {
+  if (encoding === "base64") return pkistudio.base64ToBytes(value);
+  return pkistudio.hexToBytes(value);
+}
+
+function bytesEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
 }


### PR DESCRIPTION
## Summary
- update `pkistudiojs` from `v0.2.2` to `v0.2.5`
- add MCP tools for ASN.1 node extraction, round-trip input normalization, node value inspection, and OID value encoding/decoding
- bump the package and MCP server metadata to `0.0.8`
- document the new tools in the README

## Verification
- `npm run check`
- `npm pack --dry-run`
- manual wrapper checks for `extractAsn1Node`, `normalizeAsn1Input`, `getAsn1NodeValue`, `encodeOidValue`, and `decodeOidValue`

Fixes #12