### PR TITLE
Add key pair generation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The package currently depends on PkiStudioJS directly from GitHub and uses key m
 - `decode_oid_value`: Decode ASN.1 OBJECT IDENTIFIER value bytes into dotted OID text.
 - `resolve_oid`: Resolve an OID using the OID names bundled with PkiStudioJS.
 - `recognize_key_material`: Recognize a PKCS#8 private key or SPKI public key and report its key family, label, and capabilities.
+- `list_supported_key_algorithms`: List WebCrypto key pair algorithms supported by the current runtime for key generation.
+- `generate_key_pair`: Generate a key pair and return the private key as PKCS#8 DER and public key as SPKI DER.
 - `verify_key_pair`: Verify that a PKCS#8 private key matches an SPKI public key by signing and verifying sample data.
 - `certificate_matches_key`: Check whether an X.509 certificate public key matches supplied public key bytes or a PKCS#8 private key.
 - `create_csr`: Create a PKCS#10 certificate signing request from a private key, public key, and subject DN.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 and PKI key material tools.",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import {
   certificateMatchesKey,
   createCsr,
   createSelfSignedCertificate,
+  generateKeyPair,
+  listSupportedKeyAlgorithms,
   readPkcs12,
   recognizeKeyMaterial,
   verifyKeyPair,
@@ -46,6 +48,27 @@ const asn1InputSchema = {
 
 const outputEncodingSchema = z.enum(["hex", "base64"]).default("hex").describe("Output encoding for DER or value bytes.");
 const hashAlgorithmSchema = z.enum(["SHA-256", "SHA-384", "SHA-512"]).default("SHA-256").describe("Hash algorithm for signing.");
+const keyAlgorithmSchema = z.enum([
+  "rsassa-pkcs1-v1_5-2048",
+  "rsassa-pkcs1-v1_5-3072",
+  "rsassa-pkcs1-v1_5-4096",
+  "rsa-pss-2048",
+  "rsa-pss-3072",
+  "rsa-pss-4096",
+  "rsa-oaep-2048",
+  "rsa-oaep-3072",
+  "rsa-oaep-4096",
+  "ecdsa-p-256",
+  "ecdsa-p-384",
+  "ecdsa-p-521",
+  "ecdh-p-256",
+  "ecdh-p-384",
+  "ecdh-p-521",
+  "ed25519",
+  "ed448",
+  "x25519",
+  "x448",
+]);
 const certificateKeyUsageSchema = z.enum([
   "digitalSignature",
   "nonRepudiation",
@@ -60,7 +83,7 @@ const certificateKeyUsageSchema = z.enum([
 
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.2.0",
+  version: "0.2.1",
 });
 
 server.registerTool(
@@ -197,6 +220,30 @@ server.registerTool(
     },
   },
   async (input) => jsonToolResult(recognizeKeyMaterial(input)),
+);
+
+server.registerTool(
+  "list_supported_key_algorithms",
+  {
+    title: "List Supported Key Algorithms",
+    description: "List WebCrypto key pair algorithms supported by this runtime for key generation.",
+    inputSchema: {},
+  },
+  async () => jsonToolResult(await listSupportedKeyAlgorithms()),
+);
+
+server.registerTool(
+  "generate_key_pair",
+  {
+    title: "Generate Key Pair",
+    description: "Generate a key pair and return the private key as PKCS#8 DER and public key as SPKI DER.",
+    inputSchema: {
+      algorithm: keyAlgorithmSchema.describe("Algorithm id from list_supported_key_algorithms, for example rsassa-pkcs1-v1_5-2048 or ecdsa-p-256."),
+      label: z.string().optional().describe("Optional friendly label to include in the response."),
+      encoding: outputEncodingSchema,
+    },
+  },
+  async (input) => jsonToolResult(await generateKeyPair(input)),
 );
 
 server.registerTool(

--- a/src/key-material.ts
+++ b/src/key-material.ts
@@ -16,6 +16,14 @@ type RecognizedKeyInfo = {
   namedCurve?: string;
 };
 
+type KeyAlgorithmCandidate = {
+  id: string;
+  canonicalId: string;
+  canonicalLabel: string;
+  algorithm: AlgorithmIdentifier | RsaHashedKeyGenParams | EcKeyGenParams;
+  usages: KeyUsage[];
+};
+
 type MaterialInput = {
   data: string;
   format?: InputFormat;
@@ -23,6 +31,12 @@ type MaterialInput = {
 
 type RecognizeInput = MaterialInput & {
   kind: "private" | "public";
+};
+
+type GenerateKeyPairInput = {
+  algorithm: string;
+  label?: string;
+  encoding?: OutputEncoding;
 };
 
 type VerifyKeyPairInput = {
@@ -95,6 +109,68 @@ const CERTIFICATE_KEY_USAGES: CertificateKeyUsage[] = [
   { id: "encipherOnly", label: "encipherOnly", bit: 7 },
   { id: "decipherOnly", label: "decipherOnly", bit: 8 },
 ];
+
+const KEY_ALGORITHM_CANDIDATES: KeyAlgorithmCandidate[] = [
+  ...createRsaCandidates("RSASSA-PKCS1-v1_5", "SHA-256", ["sign", "verify"]),
+  ...createRsaCandidates("RSA-PSS", "SHA-256", ["sign", "verify"]),
+  ...createRsaCandidates("RSA-OAEP", "SHA-256", ["encrypt", "decrypt"]),
+  ...createNamedCurveCandidates("ECDSA", ["P-256", "P-384", "P-521"], ["sign", "verify"]),
+  ...createNamedCurveCandidates("ECDH", ["P-256", "P-384", "P-521"], ["deriveBits"]),
+  ...createNamedCurveCandidates("Ed25519", ["Ed25519"], ["sign", "verify"]),
+  ...createNamedCurveCandidates("Ed448", ["Ed448"], ["sign", "verify"]),
+  ...createNamedCurveCandidates("X25519", ["X25519"], ["deriveBits"]),
+  ...createNamedCurveCandidates("X448", ["X448"], ["deriveBits"]),
+];
+
+export async function listSupportedKeyAlgorithms() {
+  const results = await Promise.all(
+    KEY_ALGORITHM_CANDIDATES.map(async (candidate) => ({
+      candidate,
+      supported: await isKeyAlgorithmSupported(candidate),
+    })),
+  );
+
+  const uniqueSupportedAlgorithms = new Map<string, KeyAlgorithmCandidate>();
+  for (const result of results) {
+    if (!result.supported || uniqueSupportedAlgorithms.has(result.candidate.canonicalId)) continue;
+    uniqueSupportedAlgorithms.set(result.candidate.canonicalId, result.candidate);
+  }
+
+  return {
+    algorithms: [...uniqueSupportedAlgorithms.values()].map(describeKeyAlgorithmCandidate),
+  };
+}
+
+export async function generateKeyPair(input: GenerateKeyPairInput) {
+  const candidate = getGenerationOptions(input.algorithm);
+  const generated = await crypto.subtle.generateKey(candidate.algorithm, true, candidate.usages);
+  if (!isCryptoKeyPair(generated)) throw new Error("The runtime did not return a key pair.");
+
+  const [privateKeyBuffer, publicKeyBuffer] = await Promise.all([
+    crypto.subtle.exportKey("pkcs8", generated.privateKey),
+    crypto.subtle.exportKey("spki", generated.publicKey),
+  ]);
+  const privateKeyDer = new Uint8Array(privateKeyBuffer);
+  const publicKeyDer = new Uint8Array(publicKeyBuffer);
+  const keyInfo = recognizeMaterial({ privateKeyDer, publicKeyDer });
+  const encoding = input.encoding ?? "hex";
+
+  return {
+    algorithm: describeKeyAlgorithmCandidate(candidate),
+    label: input.label || keyInfo.label,
+    keyInfo,
+    privateKey: {
+      encoding,
+      length: privateKeyDer.length,
+      data: encodeOutputBytes(privateKeyDer, encoding),
+    },
+    publicKey: {
+      encoding,
+      length: publicKeyDer.length,
+      data: encodeOutputBytes(publicKeyDer, encoding),
+    },
+  };
+}
 
 export function recognizeKeyMaterial(input: RecognizeInput) {
   const decoded = decodeInputBytes(input.data, input.format);
@@ -289,6 +365,60 @@ export async function writePkcs12(input: WritePkcs12Input) {
 function recognizeMaterial(material: { privateKeyDer?: Uint8Array; publicKeyDer?: Uint8Array }): RecognizedKeyInfo {
   return (material.publicKeyDer ? recognizePublicKey(material.publicKeyDer) : null) ||
     (material.privateKeyDer ? recognizePrivateKey(material.privateKeyDer) : createRecognizedKeyInfo("Unknown", "Unknown"));
+}
+
+function getGenerationOptions(selection: string): KeyAlgorithmCandidate {
+  const supported = KEY_ALGORITHM_CANDIDATES.find((candidate) => candidate.id === selection);
+  if (!supported) throw new Error(`Unsupported algorithm: ${selection || "(none selected)"}`);
+  return supported;
+}
+
+async function isKeyAlgorithmSupported(candidate: KeyAlgorithmCandidate): Promise<boolean> {
+  try {
+    const generated = await crypto.subtle.generateKey(candidate.algorithm, true, candidate.usages);
+    return isCryptoKeyPair(generated);
+  } catch {
+    return false;
+  }
+}
+
+function createRsaCandidates(name: string, hash: string, usages: KeyUsage[]): KeyAlgorithmCandidate[] {
+  return [2048, 3072, 4096].map((modulusLength) => ({
+    id: `${name.toLowerCase()}-${modulusLength}`,
+    canonicalId: `rsa-${modulusLength}`,
+    canonicalLabel: `RSA ${modulusLength}`,
+    algorithm: {
+      name,
+      modulusLength,
+      publicExponent: new Uint8Array([0x01, 0x00, 0x01]),
+      hash,
+    },
+    usages,
+  }));
+}
+
+function createNamedCurveCandidates(name: string, curves: string[], usages: KeyUsage[]): KeyAlgorithmCandidate[] {
+  return curves.map((namedCurve) => ({
+    id: name === namedCurve ? name.toLowerCase() : `${name.toLowerCase()}-${namedCurve.toLowerCase()}`,
+    canonicalId: name === "ECDSA" || name === "ECDH" ? `ec-${namedCurve.toLowerCase()}` : name.toLowerCase(),
+    canonicalLabel: name === "ECDSA" || name === "ECDH" ? `EC ${namedCurve}` : name,
+    algorithm: name === namedCurve ? { name } : { name, namedCurve },
+    usages,
+  }));
+}
+
+function isCryptoKeyPair(value: CryptoKey | CryptoKeyPair): value is CryptoKeyPair {
+  return "privateKey" in value && "publicKey" in value;
+}
+
+function describeKeyAlgorithmCandidate(candidate: KeyAlgorithmCandidate) {
+  return {
+    id: candidate.id,
+    canonicalId: candidate.canonicalId,
+    label: candidate.canonicalLabel,
+    algorithm: candidate.algorithm,
+    usages: candidate.usages,
+  };
 }
 
 function recognizePublicKey(bytes: Uint8Array): RecognizedKeyInfo | null {


### PR DESCRIPTION
Adds runtime-aware key pair generation to the MCP server for the 0.2.1 release.

Summary:
- Add `list_supported_key_algorithms` to report WebCrypto key pair algorithms supported by the current runtime.
- Add `generate_key_pair` to generate key material and return PKCS#8 private key DER plus SPKI public key DER.
- Bump package, lockfile, and MCP server metadata to 0.2.1.
- Document the new tools in the README.

Verification:
- `npm run check`
- `npm pack --dry-run`
- Smoke tested `listSupportedKeyAlgorithms()` and `generateKeyPair({ algorithm: "ecdsa-p-256", encoding: "base64" })` from the built output.

Fixes #14