### PR TITLE
Fix async MCP key material responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 and PKI key material tools.",
   "type": "module",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ const certificateKeyUsageSchema = z.enum([
 
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.2.1",
+  version: "0.2.2",
 });
 
 server.registerTool(
@@ -258,7 +258,7 @@ server.registerTool(
       publicKeyFormat: optionalInputFormatSchema,
     },
   },
-  async (input) => jsonToolResult(verifyKeyPair(input)),
+  async (input) => jsonToolResult(await verifyKeyPair(input)),
 );
 
 server.registerTool(
@@ -276,7 +276,7 @@ server.registerTool(
       encoding: outputEncodingSchema,
     },
   },
-  async (input) => jsonToolResult(certificateMatchesKey(input)),
+  async (input) => jsonToolResult(await certificateMatchesKey(input)),
 );
 
 server.registerTool(
@@ -294,7 +294,7 @@ server.registerTool(
       encoding: outputEncodingSchema,
     },
   },
-  async (input) => jsonToolResult(createCsr(input)),
+  async (input) => jsonToolResult(await createCsr(input)),
 );
 
 server.registerTool(
@@ -314,7 +314,7 @@ server.registerTool(
       encoding: outputEncodingSchema,
     },
   },
-  async (input) => jsonToolResult(createSelfSignedCertificate(input)),
+  async (input) => jsonToolResult(await createSelfSignedCertificate(input)),
 );
 
 server.registerTool(
@@ -330,7 +330,7 @@ server.registerTool(
       encoding: outputEncodingSchema,
     },
   },
-  async (input) => jsonToolResult(readPkcs12(input)),
+  async (input) => jsonToolResult(await readPkcs12(input)),
 );
 
 server.registerTool(
@@ -350,7 +350,7 @@ server.registerTool(
       encoding: outputEncodingSchema,
     },
   },
-  async (input) => jsonToolResult(writePkcs12(input)),
+  async (input) => jsonToolResult(await writePkcs12(input)),
 );
 
 async function main(): Promise<void> {


### PR DESCRIPTION
Fix MCP key material tools that returned empty JSON objects because asynchronous helper results were not awaited before JSON serialization.

Summary:
- Await async key material helpers before passing results to `jsonToolResult`.
- Bump package and MCP server metadata to `0.2.2` for release.

Verification:
- `npm run check`
- `npm pack --dry-run`
- MCP stdio smoke test for `create_self_signed_certificate` and `certificate_matches_key`
- OpenSSL self-signed certificate verification

Fixes #16