### PR TITLE
Update pvkgadgets scoped dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The package uses the published PkiStudioJS and Private Key Gadgets npm APIs:
 {
 	"dependencies": {
 		"pkistudiojs": "^0.4.1",
-		"pvkgadgets": "^0.2.0"
+		"@pkistudio/pvkgadgets": "^0.3.0"
 	}
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@pkistudio/pvkgadgets": "^0.3.0",
         "asn1js": "^3.0.10",
         "pkistudiojs": "^0.4.1",
-        "pvkgadgets": "^0.2.0",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -531,6 +531,18 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pkistudio/pvkgadgets": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pkistudio/pvkgadgets/-/pvkgadgets-0.3.0.tgz",
+      "integrity": "sha512-rI5ELNFPeth6pj7uZefIGS7B7gZCWDjjD7iBbBtY9U67DKrqDSEn9yWZt/QXSRXFMXeIyzLPov46MgObeZ9qTg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.10",
+        "pkijs": "^3.4.0",
+        "pkistudiojs": "^0.4.1",
+        "pvtsutils": "^1.3.6"
       }
     },
     "node_modules/@types/node": {
@@ -1425,18 +1437,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pvkgadgets": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pvkgadgets/-/pvkgadgets-0.2.0.tgz",
-      "integrity": "sha512-c/YWmiCQD+VHSBCDdaPe6gPyLAN3rCJlkisLIqbzfYtYk3ufb2SQmLyZ5dbvnORZLTkRsfUsy9p1+np7dZtfyA==",
-      "license": "MIT",
-      "dependencies": {
-        "asn1js": "^3.0.10",
-        "pkijs": "^3.4.0",
-        "pkistudiojs": "^0.4.1",
-        "pvtsutils": "^1.3.6"
       }
     },
     "node_modules/pvtsutils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 and PKI key material tools.",
   "type": "module",
   "repository": {
@@ -43,9 +43,9 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@pkistudio/pvkgadgets": "^0.3.0",
     "asn1js": "^3.0.10",
     "pkistudiojs": "^0.4.1",
-    "pvkgadgets": "^0.2.0",
     "zod": "^4.4.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ const certificateKeyUsageSchema = z.enum([
 
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.3.0",
+  version: "0.3.1",
 });
 
 server.registerTool(

--- a/src/key-material.ts
+++ b/src/key-material.ts
@@ -1,6 +1,6 @@
 import * as asn1js from "asn1js";
-import { PkiGadgetsCore, type KeyAlgorithmCandidate } from "pvkgadgets";
-import type { Pkcs12KeyMaterial } from "pvkgadgets/pkcs12";
+import { PvkGadgetsCore, type KeyAlgorithmCandidate } from "@pkistudio/pvkgadgets";
+import type { Pkcs12KeyMaterial } from "@pkistudio/pvkgadgets/pkcs12";
 
 import { decodeInputBytes, encodeOutputBytes } from "./pkistudio.js";
 
@@ -76,16 +76,16 @@ type WritePkcs12Input = {
 };
 
 export async function listSupportedKeyAlgorithms() {
-  const algorithms = await PkiGadgetsCore.getSupportedKeyAlgorithms();
+  const algorithms = await PvkGadgetsCore.getSupportedKeyAlgorithms();
   return { algorithms: algorithms.map(describeKeyAlgorithmCandidate) };
 }
 
 export async function generateKeyPair(input: GenerateKeyPairInput) {
-  const material = await PkiGadgetsCore.generateKeyPair(input.algorithm, { label: input.label });
+  const material = await PvkGadgetsCore.generateKeyPair(input.algorithm, { label: input.label });
   if (!material.privateKeyDer || !material.publicKeyDer) throw new Error("The runtime did not return a key pair.");
 
   const encoding = input.encoding ?? "hex";
-  const keyInfo = PkiGadgetsCore.recognizeKeyMaterial({
+  const keyInfo = PvkGadgetsCore.recognizeKeyMaterial({
     privateKeyDer: material.privateKeyDer,
     publicKeyDer: material.publicKeyDer,
   });
@@ -102,8 +102,8 @@ export async function generateKeyPair(input: GenerateKeyPairInput) {
 export function recognizeKeyMaterial(input: RecognizeInput) {
   const decoded = decodeInputBytes(input.data, input.format);
   const info = input.kind === "public"
-    ? PkiGadgetsCore.recognizeKeyMaterial({ publicKeyDer: decoded.bytes })
-    : PkiGadgetsCore.recognizeKeyMaterial({ privateKeyDer: decoded.bytes });
+    ? PvkGadgetsCore.recognizeKeyMaterial({ publicKeyDer: decoded.bytes })
+    : PvkGadgetsCore.recognizeKeyMaterial({ privateKeyDer: decoded.bytes });
 
   return {
     kind: input.kind,
@@ -116,8 +116,8 @@ export function recognizeKeyMaterial(input: RecognizeInput) {
 export async function verifyKeyPair(input: VerifyKeyPairInput) {
   const privateKey = decodeInputBytes(input.privateKey, input.privateKeyFormat);
   const publicKey = decodeInputBytes(input.publicKey, input.publicKeyFormat);
-  const keyInfo = PkiGadgetsCore.recognizeKeyMaterial({ privateKeyDer: privateKey.bytes, publicKeyDer: publicKey.bytes });
-  const matches = await PkiGadgetsCore.verifyPrivateKeyMatchesPublicKey(privateKey.bytes, publicKey.bytes, keyInfo);
+  const keyInfo = PvkGadgetsCore.recognizeKeyMaterial({ privateKeyDer: privateKey.bytes, publicKeyDer: publicKey.bytes });
+  const matches = await PvkGadgetsCore.verifyPrivateKeyMatchesPublicKey(privateKey.bytes, publicKey.bytes, keyInfo);
 
   return {
     matches,
@@ -136,16 +136,16 @@ export async function certificateMatchesKey(input: CertificateMatchesKeyInput) {
 
   const certificate = decodeInputBytes(input.certificate, input.certificateFormat);
   const certificatePublicKeyDer = getCertificatePublicKeyDer(certificate.bytes);
-  const certificatePublicKeyInfo = PkiGadgetsCore.recognizeKeyMaterial({ publicKeyDer: certificatePublicKeyDer });
+  const certificatePublicKeyInfo = PvkGadgetsCore.recognizeKeyMaterial({ publicKeyDer: certificatePublicKeyDer });
   const publicKey = input.publicKey ? decodeInputBytes(input.publicKey, input.publicKeyFormat) : undefined;
   const privateKey = input.privateKey ? decodeInputBytes(input.privateKey, input.privateKeyFormat) : undefined;
-  const keyInfo = PkiGadgetsCore.recognizeKeyMaterial({
+  const keyInfo = PvkGadgetsCore.recognizeKeyMaterial({
     privateKeyDer: privateKey?.bytes,
     publicKeyDer: publicKey?.bytes,
   });
   const matches = publicKey
-    ? PkiGadgetsCore.bytesEqual(publicKey.bytes, certificatePublicKeyDer)
-    : await PkiGadgetsCore.verifyPrivateKeyMatchesPublicKey(privateKey?.bytes ?? new Uint8Array(), certificatePublicKeyDer, keyInfo);
+    ? PvkGadgetsCore.bytesEqual(publicKey.bytes, certificatePublicKeyDer)
+    : await PvkGadgetsCore.verifyPrivateKeyMatchesPublicKey(privateKey?.bytes ?? new Uint8Array(), certificatePublicKeyDer, keyInfo);
 
   return {
     matches,
@@ -165,12 +165,12 @@ export async function createCsr(input: CreateCsrInput) {
   const privateKey = decodeInputBytes(input.privateKey, input.privateKeyFormat);
   const publicKey = decodeInputBytes(input.publicKey, input.publicKeyFormat);
   const hashAlgorithm = input.hashAlgorithm ?? "SHA-256";
-  const keyInfo = PkiGadgetsCore.recognizeKeyMaterial({ privateKeyDer: privateKey.bytes, publicKeyDer: publicKey.bytes });
-  const result = await PkiGadgetsCore.createCsr({
+  const keyInfo = PvkGadgetsCore.recognizeKeyMaterial({ privateKeyDer: privateKey.bytes, publicKeyDer: publicKey.bytes });
+  const result = await PvkGadgetsCore.createCsr({
     privateKeyDer: privateKey.bytes,
     publicKeyDer: publicKey.bytes,
     subjectDn: input.subjectDn,
-    subjectBytes: PkiGadgetsCore.createSubjectDn(input.subjectDn),
+    subjectBytes: PvkGadgetsCore.createSubjectDn(input.subjectDn),
     hashAlgorithm,
   });
 
@@ -192,12 +192,12 @@ export async function createSelfSignedCertificate(input: CreateSelfSignedCertifi
   const keyUsages = input.keyUsages ?? ["digitalSignature", "keyCertSign", "cRLSign"];
   const notBefore = new Date();
   const notAfter = new Date(notBefore.getTime() + validityDays * 24 * 60 * 60 * 1000);
-  const keyInfo = PkiGadgetsCore.recognizeKeyMaterial({ privateKeyDer: privateKey.bytes, publicKeyDer: publicKey.bytes });
-  const result = await PkiGadgetsCore.createSelfSignedCertificate({
+  const keyInfo = PvkGadgetsCore.recognizeKeyMaterial({ privateKeyDer: privateKey.bytes, publicKeyDer: publicKey.bytes });
+  const result = await PvkGadgetsCore.createSelfSignedCertificate({
     privateKeyDer: privateKey.bytes,
     publicKeyDer: publicKey.bytes,
     subjectDn: input.subjectDn,
-    subjectBytes: PkiGadgetsCore.createSubjectDn(input.subjectDn),
+    subjectBytes: PvkGadgetsCore.createSubjectDn(input.subjectDn),
     hashAlgorithm,
     validityDays,
     keyUsages,
@@ -219,7 +219,7 @@ export async function createSelfSignedCertificate(input: CreateSelfSignedCertifi
 
 export async function readPkcs12(input: ReadPkcs12Input) {
   const decoded = decodeInputBytes(input.data, input.format);
-  const keys: Pkcs12KeyMaterial[] = await PkiGadgetsCore.readPkcs12(decoded.bytes, input.password, { sourceName: input.sourceName });
+  const keys: Pkcs12KeyMaterial[] = await PvkGadgetsCore.readPkcs12(decoded.bytes, input.password, { sourceName: input.sourceName });
   const encoding = input.encoding ?? "hex";
 
   return {
@@ -229,7 +229,7 @@ export async function readPkcs12(input: ReadPkcs12Input) {
       id: key.id,
       label: key.label,
       sourceName: key.sourceName,
-      keyInfo: PkiGadgetsCore.recognizeKeyMaterial({ privateKeyDer: key.privateKeyDer, publicKeyDer: key.publicKeyDer }),
+      keyInfo: PvkGadgetsCore.recognizeKeyMaterial({ privateKeyDer: key.privateKeyDer, publicKeyDer: key.publicKeyDer }),
       privateKey: describeBytes(key.privateKeyDer, encoding),
       publicKey: key.publicKeyDer ? describeBytes(key.publicKeyDer, encoding) : undefined,
       certificate: key.certificateDer ? describeBytes(key.certificateDer, encoding) : undefined,
@@ -238,7 +238,7 @@ export async function readPkcs12(input: ReadPkcs12Input) {
 }
 
 export async function writePkcs12(input: WritePkcs12Input) {
-  const bytes = await PkiGadgetsCore.writePkcs12(
+  const bytes = await PvkGadgetsCore.writePkcs12(
     input.keys.map((key) => ({
       label: key.label,
       privateKeyDer: decodeInputBytes(key.privateKey, key.privateKeyFormat).bytes,
@@ -256,7 +256,7 @@ export async function writePkcs12(input: WritePkcs12Input) {
 }
 
 function getGenerationOptions(selection: string): KeyAlgorithmCandidate {
-  const supported = PkiGadgetsCore.keyAlgorithms.find((candidate) => candidate.id === selection);
+  const supported = PvkGadgetsCore.keyAlgorithms.find((candidate) => candidate.id === selection);
   if (!supported) throw new Error(`Unsupported algorithm: ${selection || "(none selected)"}`);
   return supported;
 }


### PR DESCRIPTION
## Summary
- Replace the legacy `pvkgadgets` dependency with `@pkistudio/pvkgadgets@^0.3.0`.
- Update key material imports and core API usage from `PkiGadgetsCore` to `PvkGadgetsCore`.
- Bump `@pkistudio/pkistudiomcp` and MCP server metadata to `0.3.1`.

## Verification
- `npm run check`
- `npm run smoke`
- `npm pack --dry-run`

Fixes #20