### PR TITLE
Update PkiStudioJS and pvkgadgets dependencies

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to publish, such as v0.3.2"
+        description: "Release tag to publish, such as v1.2.3"
         required: true
         type: string
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ The package uses the published PkiStudioJS and Private Key Gadgets npm APIs:
 ```json
 {
 	"dependencies": {
-		"pkistudiojs": "^0.4.1",
-		"@pkistudio/pvkgadgets": "^0.3.0"
+		"@pkistudio/pkistudiojs": "^0.5.0",
+		"@pkistudio/pvkgadgets": "^0.3.1"
 	}
 }
 ```
+
+PkiStudioJS `0.5.x` is published as the scoped `@pkistudio/pkistudiojs` package. Its browser viewer also supports native read-only mode through `viewer.init({ editable: false })` and `setEditable(false)`. This MCP server uses the PkiStudioJS Core API rather than embedding the browser viewer, so the ASN.1 tools remain string-in/string-out MCP operations and do not expose a separate viewer editability option.
 
 ## What can I ask my AI assistant?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@pkistudio/pvkgadgets": "^0.3.0",
+        "@pkistudio/pkistudiojs": "^0.5.0",
+        "@pkistudio/pvkgadgets": "^0.3.1",
         "asn1js": "^3.0.10",
-        "pkistudiojs": "^0.4.1",
         "zod": "^4.4.1"
       },
       "bin": {
@@ -533,15 +533,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@pkistudio/pkistudiojs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pkistudio/pkistudiojs/-/pkistudiojs-0.5.0.tgz",
+      "integrity": "sha512-DBU8KwMp6rW4WAAbnpYSUqZl2J1Bwj9fTV9tOMsdbqGFoqsM5ePANiQeAopVMgn6iB9XieD9JAzQ2PYFQLNY7g==",
+      "license": "MIT"
+    },
     "node_modules/@pkistudio/pvkgadgets": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pkistudio/pvkgadgets/-/pvkgadgets-0.3.0.tgz",
-      "integrity": "sha512-rI5ELNFPeth6pj7uZefIGS7B7gZCWDjjD7iBbBtY9U67DKrqDSEn9yWZt/QXSRXFMXeIyzLPov46MgObeZ9qTg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@pkistudio/pvkgadgets/-/pvkgadgets-0.3.1.tgz",
+      "integrity": "sha512-P/pSZqHb5YSeTQT08yjscnHj7hJvUXS8gQwcZ0n16AOCdqG/yf9DfNs71UpD2zGb/3OJuBspDv422DGNVXr21g==",
       "license": "MIT",
       "dependencies": {
+        "@pkistudio/pkistudiojs": "^0.5.0",
         "asn1js": "^3.0.10",
         "pkijs": "^3.4.0",
-        "pkistudiojs": "^0.4.1",
         "pvtsutils": "^1.3.6"
       }
     },
@@ -1419,12 +1425,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/pkistudiojs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkistudiojs/-/pkistudiojs-0.4.1.tgz",
-      "integrity": "sha512-pGleJVmcG86w/BxcmxBog5at/lvbStFT2UiOUhHpj37NtWLbX41PdSMCkZXtAePbqGkoLDzMDNz1tp0bfNz8iA==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 and PKI key material tools.",
   "type": "module",
   "repository": {
@@ -43,9 +43,9 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@pkistudio/pvkgadgets": "^0.3.0",
+    "@pkistudio/pkistudiojs": "^0.5.0",
+    "@pkistudio/pvkgadgets": "^0.3.1",
     "asn1js": "^3.0.10",
-    "pkistudiojs": "^0.4.1",
     "zod": "^4.4.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ const certificateKeyUsageSchema = z.enum([
 
 const server = new McpServer({
   name: "@pkistudio/pkistudiomcp",
-  version: "0.3.2",
+  version: "0.3.3",
 });
 
 server.registerTool(

--- a/src/pkistudio.ts
+++ b/src/pkistudio.ts
@@ -99,7 +99,7 @@ type DecodeOidInput = {
 };
 
 const require = createRequire(import.meta.url);
-const pkistudio = require("pkistudiojs") as PkiStudioCore;
+const pkistudio = require("@pkistudio/pkistudiojs") as PkiStudioCore;
 
 let oidNames: Record<string, string> | undefined;
 
@@ -107,7 +107,7 @@ export function loadOidNames(): Record<string, string> {
   if (oidNames) return oidNames;
 
   try {
-    const corePath = require.resolve("pkistudiojs");
+    const corePath = require.resolve("@pkistudio/pkistudiojs");
     oidNames = require(join(dirname(corePath), "oids.json")) as Record<string, string>;
   } catch {
     oidNames = {};


### PR DESCRIPTION
Summary:
- Replace the legacy `pkistudiojs` dependency with scoped `@pkistudio/pkistudiojs`.
- Update `@pkistudio/pvkgadgets` to `^0.3.1`, which also depends on scoped PkiStudioJS.
- Resolve the PkiStudioJS Core API and bundled OID table through the scoped package.
- Document the dependency change and clarify that PkiStudioJS viewer read-only mode is a browser viewer feature, while this MCP server uses the Core API.
- Bump package and MCP server metadata to 0.3.3.

Release notes draft:
Update PkiStudioJS and pvkgadgets dependencies to the scoped PkiStudioJS package generation, with README notes about PkiStudioJS viewer read-only mode.

Verification:
- `npm run check`
- `npm run smoke`
- `npm pack --dry-run`

Closes #24