### PR TITLE
Add Docker Hub image publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.devcontainer
+.git
+.github
+.vscode
+dist
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,66 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, such as v1.2.3"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Compute version
+        id: version
+        run: |
+          release_tag="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          version="${release_tag#v}"
+          if [[ -z "$version" || "$version" == "$release_tag" ]]; then
+            echo "Could not determine package version from release tag $release_tag."
+            exit 1
+          fi
+          actual_version="$(node -p "require('./package.json').version")"
+          if [[ "$actual_version" != "$version" ]]; then
+            echo "package.json version $actual_version does not match expected version $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            pkistudio/pkistudiomcp:${{ steps.version.outputs.version }}
+            pkistudio/pkistudiomcp:latest
+          labels: |
+            org.opencontainers.image.title=pkistudiomcp
+            org.opencontainers.image.description=PKI Studio MCP server
+            org.opencontainers.image.source=https://github.com/pkistudio/pkistudiomcp
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.licenses=MIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24-alpine AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:24-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PKISTUDIOMCP_HTTP_HOST=0.0.0.0
+ENV PKISTUDIOMCP_HTTP_PORT=3000
+ENV PKISTUDIOMCP_HTTP_PATH=/mcp
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
+
+COPY --from=build /app/dist ./dist
+COPY README.md LICENSE ./
+
+USER node
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:' + (process.env.PKISTUDIOMCP_HTTP_PORT || '3000') + '/healthz').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["node", "dist/http.js"]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ node dist/http.js
 
 The HTTP MCP endpoint defaults to `http://127.0.0.1:3000/mcp`, and health checks are available at `http://127.0.0.1:3000/healthz`. Configure the MCP endpoint path with `PKISTUDIOMCP_HTTP_PATH`, and configure the bind address with `PKISTUDIOMCP_HTTP_HOST` and `PKISTUDIOMCP_HTTP_PORT`.
 
+Run the published Docker image:
+
+```sh
+docker run --rm -p 3000:3000 pkistudio/pkistudiomcp:latest
+```
+
+The Docker image starts the Streamable HTTP server by default. Its MCP endpoint is `http://127.0.0.1:3000/mcp`, and its health check is `http://127.0.0.1:3000/healthz`.
+
+Pin a release version when reproducibility matters:
+
+```sh
+docker run --rm -p 3000:3000 pkistudio/pkistudiomcp:0.4.0
+```
+
+To run the stdio server from the image instead:
+
+```sh
+docker run --rm -i pkistudio/pkistudiomcp:latest node dist/index.js
+```
+
 During development, you can also run the TypeScript entry point directly:
 
 ```sh


### PR DESCRIPTION
## Summary
- Dockerfile: Multi-stage build for PKI Studio MCP.
- .dockerignore: Optimized for production builds.
- Docker Hub publish workflow: Automated GitHub Action for publishing to Docker Hub.
- README Docker usage: Added instructions for running with Docker.

## Verification
- [x] `npm run check` passed.
- [x] `docker build -t pkistudio/pkistudiomcp:0.4.0-local .` successful.
- [x] Local Docker run verified with `/healthz` and `/mcp` endpoints.
- [x] Docker Hub push of `pkistudio/pkistudiomcp:0.4.0` and `latest` with digest `sha256:f60b7c308d7c2bd498655097db3cfdd65aa53787d6afdf8d5b2badacf67a3329`.
- [x] Docker Hub pull/run verification complete.

Fixes #28