### PR TITLE
Add Azure deployment workflow

### DIFF
--- a/.github/prompts/release.prompt.md
+++ b/.github/prompts/release.prompt.md
@@ -1,5 +1,5 @@
 ---
-description: "Use when: running the pkistudiomcp issue-to-release workflow, including issue creation, branch work, PR, merge, npm publish, tag, GitHub Release, and verification checks."
+description: "Use when: running the pkistudiomcp issue-to-release workflow, including issue creation, branch work, PR, merge, npm publish, Docker publish, Azure Container Apps deploy, tag, GitHub Release, and verification checks."
 name: "pkistudiomcp release workflow"
 argument-hint: "[version|TBD] [#issue] <short feature or fix summary>"
 agent: "agent"
@@ -7,7 +7,7 @@ agent: "agent"
 
 # pkistudiomcp Release Workflow
 
-Run the standard `pkistudio/pkistudiomcp` release workflow from issue creation through GitHub Release publication, npm publication, and post-release verification.
+Run the standard `pkistudio/pkistudiomcp` release workflow from issue creation through GitHub Release publication, npm publication, Docker publication, Azure Container Apps deployment, and post-release verification.
 
 Expected invocation examples:
 
@@ -31,7 +31,7 @@ Default assumptions:
 - If no issue number is supplied, create a tracking issue first.
 - If an issue number is supplied, use that issue as the source of truth.
 - Create a branch from the issue, implement the requested change, verify it, push it, and open a PR.
-- Use the issue body, issue comments, and PR body to preserve the release rationale, release notes draft, verification results, npm status, and publication status.
+- Use the issue body, issue comments, and PR body to preserve the release rationale, release notes draft, verification results, npm status, Docker status, Azure deployment status, and publication status.
 - Do not merge, tag, publish, or create a GitHub Release until the user explicitly says to proceed.
 
 Ask only when:
@@ -44,15 +44,17 @@ Ask only when:
 Confirmation gates:
 
 - Gate 1: PR merge.
-- Gate 2: version bump, tag push, GitHub Release creation, and the automatic npm publish trigger caused by the tag.
-- Gate 3: npm publish workflow rerun or manual npm publication if the tag-triggered publish needs intervention.
-- Gate 4: post-publication registry, fresh-install, MCP startup, and Actions verification.
+- Gate 2: version bump, tag push, GitHub Release creation, and the automatic npm and Docker publish triggers caused by the tag. Docker publication calls the Azure deployment workflow after a successful image push.
+- Gate 3: npm, Docker, or Azure workflow rerun; manual npm publication; or manual Azure deployment if the tag-triggered publication needs intervention.
+- Gate 4: post-publication registry, fresh-install, MCP startup, Docker image, Azure health endpoint, and Actions verification.
 
 ## Required Safety Rules
 
 - This prompt is a workflow guide only and does not grant repository permissions.
 - Push, tag, release, merge, and secret-backed Actions operations are possible only for users or tokens with the required repository permissions.
 - npm publication requires npm package ownership or a configured npm Trusted Publisher for `@pkistudio/pkistudiomcp` and `.github/workflows/publish-npm.yml`.
+- Docker publication requires Docker Hub credentials configured for `.github/workflows/publish-docker.yml`.
+- Azure deployment requires GitHub Actions OpenID Connect credentials and repository variables configured for `.github/workflows/deploy-azure.yml`.
 - Work in the current repository only.
 - Confirm the repository is `pkistudio/pkistudiomcp` unless the user intentionally targets another repo.
 - Check the current branch, remote, and working tree before making changes.
@@ -109,6 +111,13 @@ Closes #<issue-number>
 - npm package access: public
 - npm publish command used by the release workflow: `npm publish --provenance --access public`
 - npm publication path: push an annotated `vX.Y.Z` tag and let `.github/workflows/publish-npm.yml` publish through npm Trusted Publishing.
+- Docker publication path: push an annotated `vX.Y.Z` tag and let `.github/workflows/publish-docker.yml` publish `docker.io/pkistudio/pkistudiomcp:X.Y.Z` and `docker.io/pkistudio/pkistudiomcp:latest`.
+- Azure deployment path: after Docker publication succeeds, `.github/workflows/publish-docker.yml` calls `.github/workflows/deploy-azure.yml` with image tag `X.Y.Z`.
+- Azure deployment workflow manual rerun command: `gh workflow run deploy-azure.yml -f tag=X.Y.Z`.
+- Azure deployment required secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`.
+- Azure deployment required repository variable: `AZURE_RESOURCE_GROUP`.
+- Azure deployment optional repository variables: `AZURE_CONTAINER_APP_NAME` and `AZURE_HEALTH_URL`.
+- Azure public health check URL: `https://pkistudiomcp.blackfield-fee115fa.japaneast.azurecontainerapps.io/healthz`.
 - Runtime command after publish: `npx -y @pkistudio/pkistudiomcp`
 - Main verification command: `npm run check`
 - Smoke verification command: `npm run smoke`
@@ -201,31 +210,44 @@ Keep the package name as `@pkistudio/pkistudiomcp`. Keep the CLI bin name as `pk
     - Once the final version is chosen, normalize it to both `X.Y.Z` and `vX.Y.Z` forms and check that the npm version and git tag do not already exist.
     - If version references were deferred, create a focused version bump commit on `main` or on a release-prep branch/PR if the user wants review before publication.
 
-11. Tag, GitHub Release, and npm Publication
-    - Create an annotated tag `vX.Y.Z` on the released `main` commit.
-    - Push the tag only after the user has approved Gate 2.
-    - The `Publish npm package` workflow runs on `v*` tag pushes and publishes with npm Trusted Publishing. It expects:
-      - npm package name: `@pkistudio/pkistudiomcp`
-      - GitHub owner/repository: `pkistudio/pkistudiomcp`
-      - workflow filename: `publish-npm.yml`
-      - npm Trusted Publishing environment: none / blank, unless the workflow is later changed to use one
-    - For scoped npm packages, `E404` during publish can mean the package does not exist yet or the workflow/account lacks scope permission.
-    - If npm publish fails with `E404` or `no permission`, explain that npm Trusted Publishing or initial package ownership is not configured. Do not keep rerunning the same job until npm permissions are fixed.
-    - Do not create a new tag just to retry npm publication when the version and tag are already correct. After fixing npm permissions or Trusted Publishing, rerun the failed publish workflow or publish manually from an authorized npm account.
-    - If the version was already published manually, do not rerun the publish job for the same tag/version; npm versions are immutable and the rerun will fail.
-    - Create a GitHub Release named `vX.Y.Z` with release notes summarizing user-facing changes, npm package information, and issue or PR references.
-    - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
-    - After publication, verify `npm view @pkistudio/pkistudiomcp@X.Y.Z version dist-tags dist.tarball --json` and, when practical, perform a fresh temporary install from npm and run the CLI entry point.
+11. Tag, GitHub Release, npm, Docker, and Azure Publication
+      - Create an annotated tag `vX.Y.Z` on the released `main` commit.
+      - Push the tag only after the user has approved Gate 2.
+      - The `Publish npm package` workflow runs on `v*` tag pushes and publishes with npm Trusted Publishing. It expects:
+         - npm package name: `@pkistudio/pkistudiomcp`
+         - GitHub owner/repository: `pkistudio/pkistudiomcp`
+         - workflow filename: `publish-npm.yml`
+         - npm Trusted Publishing environment: none / blank, unless the workflow is later changed to use one
+      - The `Publish Docker image` workflow runs on `v*` tag pushes and publishes the versioned image and `latest` image to Docker Hub. It expects:
+         - Docker image name: `docker.io/pkistudio/pkistudiomcp`
+         - Docker Hub credentials: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
+         - workflow filename: `publish-docker.yml`
+      - After Docker publication succeeds, the Docker workflow calls `Deploy Azure Container Apps` with the release image tag. It expects:
+         - Azure workflow filename: `deploy-azure.yml`
+         - Azure OpenID Connect secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`
+         - Azure resource group repository variable: `AZURE_RESOURCE_GROUP`
+         - Azure Container App repository variable: `AZURE_CONTAINER_APP_NAME`, defaulting to `pkistudiomcp` when omitted
+         - Azure health URL repository variable: `AZURE_HEALTH_URL`, defaulting to the public `/healthz` endpoint when omitted
+      - For scoped npm packages, `E404` during publish can mean the package does not exist yet or the workflow/account lacks scope permission.
+      - If npm publish fails with `E404` or `no permission`, explain that npm Trusted Publishing or initial package ownership is not configured. Do not keep rerunning the same job until npm permissions are fixed.
+      - Do not create a new tag just to retry npm publication when the version and tag are already correct. After fixing npm permissions or Trusted Publishing, rerun the failed publish workflow or publish manually from an authorized npm account.
+      - If the version was already published manually, do not rerun the publish job for the same tag/version; npm versions are immutable and the rerun will fail.
+      - Do not create a new tag just to retry Docker publication or Azure deployment when the version and tag are already correct. After fixing Docker or Azure configuration, rerun the failed workflow or run `gh workflow run deploy-azure.yml -f tag=X.Y.Z` for Azure-only redeployment.
+      - Create a GitHub Release named `vX.Y.Z` with release notes summarizing user-facing changes, npm package information, and issue or PR references.
+      - Mark it as the latest stable release, not draft and not prerelease, unless instructed otherwise.
+      - After publication, verify `npm view @pkistudio/pkistudiomcp@X.Y.Z version dist-tags dist.tarball --json`, inspect Docker manifests for `docker.io/pkistudio/pkistudiomcp:X.Y.Z` and `docker.io/pkistudio/pkistudiomcp:latest`, confirm Azure deployment workflow success, and, when practical, perform a fresh temporary install from npm and run the CLI entry point.
 
 12. Confirm Final State
-    - Verify:
-      - PR is merged and closed.
-      - issue is closed as completed or its remaining state is reported.
-      - npm `latest` points to `X.Y.Z`.
-      - tag exists on `main` HEAD.
-      - GitHub Release is published.
-      - relevant GitHub Actions completed or are still running.
-    - Final response must include issue, PR, npm package version, release, tag, verification summary, and any Actions status.
+      - Verify:
+         - PR is merged and closed.
+         - issue is closed as completed or its remaining state is reported.
+         - npm `latest` points to `X.Y.Z`.
+         - Docker Hub has `X.Y.Z` and `latest` images.
+         - Azure Container Apps deployment workflow completed successfully and the health endpoint responds.
+         - tag exists on `main` HEAD.
+         - GitHub Release is published.
+         - relevant GitHub Actions completed or are still running.
+      - Final response must include issue, PR, npm package version, Docker image status, Azure deployment status, release, tag, verification summary, and any Actions status.
 
 ## Final Response Format
 
@@ -234,6 +256,8 @@ Keep the final response concise and include:
 - Issue link and state
 - PR link and merge state
 - npm package link and published version
+- Docker image publication state
+- Azure deployment state and health check
 - Release link and tag
 - Verification summary
 - Actions status

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,0 +1,120 @@
+name: Deploy Azure Container Apps
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Docker image tag to deploy, such as 0.5.0 or latest"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag to deploy, such as 0.5.0 or latest"
+        required: true
+        default: latest
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy to Azure Container Apps
+    runs-on: ubuntu-latest
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_CONTAINER_APP_NAME: ${{ vars.AZURE_CONTAINER_APP_NAME || 'pkistudiomcp' }}
+      AZURE_HEALTH_URL: ${{ vars.AZURE_HEALTH_URL || 'https://pkistudiomcp.blackfield-fee115fa.japaneast.azurecontainerapps.io/healthz' }}
+      IMAGE_REPOSITORY: docker.io/pkistudio/pkistudiomcp
+    steps:
+      - name: Compute image reference
+        id: image
+        shell: bash
+        run: |
+          image_tag="${{ inputs.tag }}"
+          image_tag="${image_tag#v}"
+
+          if [[ -z "$image_tag" ]]; then
+            echo "::error::Docker image tag is required."
+            exit 1
+          fi
+
+          if [[ ! "$image_tag" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::Invalid Docker image tag: $image_tag"
+            exit 1
+          fi
+
+          echo "tag=$image_tag" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE_REPOSITORY}:${image_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Azure configuration
+        shell: bash
+        run: |
+          missing=0
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_RESOURCE_GROUP AZURE_CONTAINER_APP_NAME; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::$name is required for Azure Container Apps deployment."
+              missing=1
+            fi
+          done
+
+          if [[ "$missing" -ne 0 ]]; then
+            exit 1
+          fi
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy image
+        shell: bash
+        run: |
+          az containerapp update \
+            --name "$AZURE_CONTAINER_APP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --image "${{ steps.image.outputs.image }}"
+
+      - name: Show deployed revision
+        shell: bash
+        run: |
+          az containerapp show \
+            --name "$AZURE_CONTAINER_APP_NAME" \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --query '{name:name, latestRevisionName:properties.latestRevisionName, latestRevisionFqdn:properties.latestRevisionFqdn, provisioningState:properties.provisioningState}' \
+            --output json
+
+      - name: Verify health endpoint
+        shell: bash
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error "$AZURE_HEALTH_URL"; then
+              echo
+              echo "Health check passed for $AZURE_HEALTH_URL"
+              exit 0
+            fi
+
+            echo "Health check attempt $attempt failed; retrying."
+            sleep 10
+          done
+
+          echo "::error::Health check failed for $AZURE_HEALTH_URL"
+          exit 1
+
+      - name: Write deployment summary
+        shell: bash
+        run: |
+          {
+            echo "### Azure Container Apps deployment"
+            echo
+            echo "- App: $AZURE_CONTAINER_APP_NAME"
+            echo "- Image: ${{ steps.image.outputs.image }}"
+            echo "- Health URL: $AZURE_HEALTH_URL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,11 +13,14 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,3 +67,14 @@ jobs:
             org.opencontainers.image.source=https://github.com/pkistudio/pkistudiomcp
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.licenses=MIT
+
+  deploy-azure:
+    name: Deploy to Azure Container Apps
+    needs: publish
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-azure.yml
+    with:
+      tag: ${{ needs.publish.outputs.version }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -112,10 +112,28 @@ The Streamable HTTP MCP endpoint is:
 https://pkistudiomcp.blackfield-fee115fa.japaneast.azurecontainerapps.io/mcp
 ```
 
-When the Docker image is updated, redeploy the latest image to Azure Container Apps with:
+When the Docker image is updated by the release workflow, GitHub Actions deploys the new release tag to Azure Container Apps through the `Deploy Azure Container Apps` workflow. The workflow can also be run manually for an existing image tag:
 
 ```sh
-az containerapp update --name pkistudiomcp --resource-group <ResourceGroupID> --image docker.io/pkistudio/pkistudiomcp:latest
+gh workflow run deploy-azure.yml -f tag=0.5.0
+```
+
+Configure these repository secrets for Azure OpenID Connect login:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+Configure these repository variables:
+
+- `AZURE_RESOURCE_GROUP` for the Container Apps resource group.
+- `AZURE_CONTAINER_APP_NAME` when the app name is not `pkistudiomcp`.
+- `AZURE_HEALTH_URL` when the health endpoint differs from the public `/healthz` URL below.
+
+The deployment workflow updates the Container App with:
+
+```sh
+az containerapp update --name pkistudiomcp --resource-group <ResourceGroupID> --image docker.io/pkistudio/pkistudiomcp:<tag>
 ```
 
 The update command itself does not contain credentials. The resource group name or ID is still environment metadata, so keep any real value out of public docs unless it is intentionally public.


### PR DESCRIPTION
Summary:
- Add a reusable/manual `Deploy Azure Container Apps` workflow.
- Call the Azure deployment workflow after the Docker image publish job succeeds.
- Document required Azure OIDC secrets and repository variables in the README.
- Update the release prompt so the standard release flow includes Docker publication, Azure deployment, health checks, and Azure rerun guidance.

Configuration needed before the Azure deployment job can succeed:
- Secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
- Required variable: `AZURE_RESOURCE_GROUP`
- Optional variables: `AZURE_CONTAINER_APP_NAME`, `AZURE_HEALTH_URL`

Verification:
- `git diff --check`
- `npm run check`
- `npm pack --dry-run`
- VS Code diagnostics for changed workflow, README, and release prompt files

Closes #32