### PR TITLE
Add ASN.1 definition sifter MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,18 @@ Use it to inspect, summarize, decode, generate, and verify:
 
 It is useful for certificate debugging, PKI development, ASN.1 inspection, and AI-assisted cryptography tooling.
 
-Under the hood, `@pkistudio/pkistudiomcp` exposes PkiStudioJS ASN.1 tools, CertGadgets certificate inspection helpers, and Private Key Gadgets PKI key material helpers as MCP tools.
+Under the hood, `@pkistudio/pkistudiomcp` exposes PkiStudioJS ASN.1 tools, ASN.1 Instance Builder schema/DER creation helpers, ASN.1 Definition Sifter candidate matching, CertGadgets certificate inspection helpers, and Private Key Gadgets PKI key material helpers as MCP tools.
 
-The package uses the published PkiStudioJS, CertGadgets, and Private Key Gadgets npm APIs:
+The package uses the published PkiStudioJS, ASN.1 Instance Builder, ASN.1 Definition Sifter, CertGadgets, and Private Key Gadgets npm APIs:
 
 ```json
 {
 	"dependencies": {
-		"@pkistudio/certgadgets": "^0.1.3",
-		"@pkistudio/pkistudiojs": "^0.6.0",
-		"@pkistudio/pvkgadgets": "^0.4.1"
+		"@pkistudio/asn1defsifter": "^0.1.3",
+		"@pkistudio/asn1instancebuilder": "^0.1.2",
+		"@pkistudio/certgadgets": "^0.1.4",
+		"@pkistudio/pkistudiojs": "^0.6.1",
+		"@pkistudio/pvkgadgets": "^0.4.2"
 	}
 }
 ```
@@ -58,6 +60,9 @@ After installing this MCP server, you can ask questions like:
 - `validate_asn1_instance`: Validate JSON instance input against a selected type in a supported ASN.1 definition subset or Schema Model JSON.
 - `create_asn1_instance`: Build DER bytes from JSON instance input and a selected type in a supported ASN.1 definition subset or Schema Model JSON.
 - `list_asn1_builder_features`: List the supported ASN.1 Instance Builder subset, JSON input shapes, and known limitations.
+- `sift_asn1_definition_candidates`: Rank ASN.1 definition candidates for ASN.1 data using custom ASN.1 definitions or the built-in PKI component corpus.
+- `sift_pki_asn1_definition_candidates`: Rank PKI ASN.1 definition candidates using the built-in ASN.1 Definition Sifter PKI corpus and optional profile filters.
+- `list_asn1_definition_sifter_features`: List ASN.1 Definition Sifter tool scope, PKI profiles, and candidate report options.
 - `recognize_key_material`: Recognize a PKCS#8 private key or SPKI public key and report its key family, label, and capabilities.
 - `list_supported_key_algorithms`: List WebCrypto key pair algorithms supported by the current runtime for key generation.
 - `generate_key_pair`: Generate a key pair and return the private key as PKCS#8 DER and public key as SPKI DER.
@@ -73,6 +78,8 @@ After installing this MCP server, you can ask questions like:
 Input is string-based. Use `format: "auto"` to let PkiStudioJS detect the input, or provide one of `der`, `ber`, `pem`, `base64`, `headerless-pem`, or `hex`.
 
 The ASN.1 Instance Builder tools create DER from a supported ASN.1 subset rather than a full ASN.1 compiler. They currently target practical PKI-oriented definitions with primitive types, constructed types, defined type references, low-form context-specific tags, module tag defaults, simple defaults, binary inputs, OID names, and schema/instance diagnostics.
+
+The ASN.1 Definition Sifter tools compare DER/TLV fragments with ASN.1 Schema Model candidates and return ranked type matches with scores, confidence labels, evidence, diagnostics, ambiguity notes, and optional bounded subtree reports. Use the generic sifter with custom ASN.1 definitions, or the PKI sifter with built-in `components`, `x509`, `pkcs10`, `pkcs8`, and `cms` profile filters.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@pkistudio/asn1defsifter": "^0.1.3",
         "@pkistudio/asn1instancebuilder": "^0.1.2",
-        "@pkistudio/certgadgets": "^0.1.3",
-        "@pkistudio/pkistudiojs": "^0.6.0",
-        "@pkistudio/pvkgadgets": "^0.4.1",
+        "@pkistudio/certgadgets": "^0.1.4",
+        "@pkistudio/pkistudiojs": "^0.6.1",
+        "@pkistudio/pvkgadgets": "^0.4.2",
         "asn1js": "^3.0.10",
         "zod": "^4.4.3"
       },
@@ -536,6 +537,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@pkistudio/asn1defsifter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@pkistudio/asn1defsifter/-/asn1defsifter-0.1.3.tgz",
+      "integrity": "sha512-M3c5YmUCOaz//3CRCKJ7qYEHKANa0Dj9GcwQGkWgjE5n7qzRHy2D70cz1LGzwGdfMaEo9XqMy+ACkC/sesvkjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pkistudio/asn1instancebuilder": "^0.1.2",
+        "@pkistudio/pkistudiojs": "^0.6.1"
+      }
+    },
     "node_modules/@pkistudio/asn1instancebuilder": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@pkistudio/asn1instancebuilder/-/asn1instancebuilder-0.1.2.tgz",
@@ -546,9 +557,9 @@
       }
     },
     "node_modules/@pkistudio/certgadgets": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@pkistudio/certgadgets/-/certgadgets-0.1.3.tgz",
-      "integrity": "sha512-KJv9LDYSeGo/rUtauC4bYFryXzxk/h4mkhy95Ujbu4Ewzt46yvl2N0wPtEA3A3mnoskyP+hQoHCCPdVbQHrJPQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@pkistudio/certgadgets/-/certgadgets-0.1.4.tgz",
+      "integrity": "sha512-BQNezwuKAx0L5SRq9ntFIQOTME89Ep0/kA8ABWvxSHimgBvQJxBnKUh79QXQHslSywY55BMln2v8eRhNGdyRcg==",
       "license": "MIT",
       "dependencies": {
         "@pkistudio/pkistudiojs": "^0.6.0",
@@ -564,9 +575,9 @@
       "license": "MIT"
     },
     "node_modules/@pkistudio/pvkgadgets": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@pkistudio/pvkgadgets/-/pvkgadgets-0.4.1.tgz",
-      "integrity": "sha512-7KXjF/Dx7KQsxGp405sdNTyJVogpq2XWUdZM+G7PODUOzpZKk5Sj6fCiTo8OH2zMBAerQzVqXOp8ZgwXHfbK4w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@pkistudio/pvkgadgets/-/pvkgadgets-0.4.2.tgz",
+      "integrity": "sha512-Td0LrA6/b6LbXx2dSpJbf21wsvHkMN6q7MvGyOFmZwty1ayTTJ4TgIlv2Y8aIis0uGUbQNnk8eLDg9NPr/FC0w==",
       "license": "MIT",
       "dependencies": {
         "@pkistudio/pkistudiojs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,11 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@pkistudio/asn1defsifter": "^0.1.3",
     "@pkistudio/asn1instancebuilder": "^0.1.2",
-    "@pkistudio/certgadgets": "^0.1.3",
-    "@pkistudio/pkistudiojs": "^0.6.0",
-    "@pkistudio/pvkgadgets": "^0.4.1",
+    "@pkistudio/certgadgets": "^0.1.4",
+    "@pkistudio/pkistudiojs": "^0.6.1",
+    "@pkistudio/pvkgadgets": "^0.4.2",
     "asn1js": "^3.0.10",
     "zod": "^4.4.3"
   },

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 
 import {
+  listAsn1DefinitionSifterFeatures,
+  siftAsn1DefinitionCandidates,
+  siftPkiAsn1DefinitionCandidates,
+} from "../dist/asn1-defsifter.js";
+import {
   createAsn1Instance,
   parseAsn1DefinitionTool,
   validateAsn1Schema,
@@ -50,6 +55,28 @@ const createdInstance = createAsn1Instance({
 assert.equal(createdInstance.built, true);
 assert.equal(createdInstance.data, "300a0c05416c69636502012a");
 assert.equal(createdInstance.derSummary?.topLevelNodes[0]?.tagName, "SEQUENCE");
+
+const sifterFeatures = listAsn1DefinitionSifterFeatures();
+assert.ok(sifterFeatures.pkiProfiles.x509.includes("Certificate"));
+
+const algorithmIdentifier = "300d06092a864886f70d01010b0500";
+const pkiSifterReport = await siftPkiAsn1DefinitionCandidates({
+  data: algorithmIdentifier,
+  format: "hex",
+  profiles: ["components"],
+  maxResults: 3,
+});
+assert.equal(pkiSifterReport.roots[0]?.summary.bestCandidate?.typeName, "AlgorithmIdentifier");
+
+const customSifterReport = await siftAsn1DefinitionCandidates({
+  data: algorithmIdentifier,
+  format: "hex",
+  definition: "Custom DEFINITIONS ::= BEGIN AlgorithmIdentifier ::= SEQUENCE { algorithm OBJECT IDENTIFIER, parameters NULL OPTIONAL } END",
+  includeTypes: ["AlgorithmIdentifier"],
+  maxResults: 3,
+});
+assert.equal(customSifterReport.corpus, "custom-definitions");
+assert.equal(customSifterReport.roots[0]?.summary.bestCandidate?.typeName, "AlgorithmIdentifier");
 
 const generated = await generateKeyPair({ algorithm: "rsassa-pkcs1-v1_5-2048", encoding: "base64" });
 assert.equal(generated.keyInfo.label, "RSA 2048");
@@ -136,6 +163,7 @@ console.log(JSON.stringify({
   certificateMatches: certificateMatch.matches,
   certificateRoot: parsedCertificate.document.root.kind,
   asn1BuilderDer: createdInstance.data,
+  asn1SifterBestCandidate: pkiSifterReport.roots[0]?.summary.bestCandidate?.typeName,
   pkcs12Length: pkcs12.length,
   importedKeys: imported.keyCount,
 }));

--- a/src/asn1-defsifter.ts
+++ b/src/asn1-defsifter.ts
@@ -1,0 +1,117 @@
+import {
+  createCandidateReport,
+  createPkiCandidateReport,
+  getPkiProfileTypeNames,
+  parseAsn1DefinitionCorpus,
+  pkiProfileTypeNames,
+  type CandidateReportOptions,
+  type PkiCandidateReportOptions,
+  type PkiProfileName,
+  type SchemaCorpus,
+} from "@pkistudio/asn1defsifter";
+
+type InputFormat = "auto" | "der" | "ber" | "pem" | "base64" | "headerless-pem" | "hex";
+
+type CandidateReportBaseInput = {
+  data: string;
+  format?: InputFormat;
+  maxResults?: number;
+  minScore?: number;
+  includeTypes?: string[];
+  excludeTypes?: string[];
+  includeNodes?: boolean;
+  includeSubtrees?: boolean;
+  includeEmptySubtrees?: boolean;
+  maxSubtreeDepth?: number;
+  maxSubtreeReports?: number;
+};
+
+type DefinitionSifterInput = CandidateReportBaseInput & {
+  definition?: string;
+  definitions?: string[];
+};
+
+type PkiDefinitionSifterInput = CandidateReportBaseInput & {
+  profiles?: PkiProfileName[];
+};
+
+export async function siftAsn1DefinitionCandidates(input: DefinitionSifterInput) {
+  const schemaCorpus = readDefinitionCorpus(input);
+  const report = await createCandidateReport(input.data, {
+    ...readCandidateReportOptions(input),
+    schemaCorpus,
+  });
+
+  return {
+    packageName: "@pkistudio/asn1defsifter",
+    corpus: schemaCorpus ? "custom-definitions" : "built-in-pki-components",
+    ...report,
+  };
+}
+
+export async function siftPkiAsn1DefinitionCandidates(input: PkiDefinitionSifterInput) {
+  const report = await createPkiCandidateReport(input.data, readPkiCandidateReportOptions(input));
+
+  return {
+    packageName: "@pkistudio/asn1defsifter",
+    profiles: input.profiles ?? [],
+    includedProfileTypes: input.profiles ? getPkiProfileTypeNames(input.profiles) : undefined,
+    ...report,
+  };
+}
+
+export function listAsn1DefinitionSifterFeatures() {
+  return {
+    packageName: "@pkistudio/asn1defsifter",
+    scope: "Rank ASN.1 definition candidates for DER/TLV fragments with explainable evidence, diagnostics, and ambiguity notes.",
+    tools: [
+      {
+        name: "sift_asn1_definition_candidates",
+        corpus: "Custom ASN.1 definitions when provided, otherwise the built-in PKI component corpus.",
+      },
+      {
+        name: "sift_pki_asn1_definition_candidates",
+        corpus: "Built-in PKI component corpus with optional profile filters.",
+      },
+    ],
+    pkiProfiles: pkiProfileTypeNames,
+    options: [
+      "maxResults",
+      "minScore",
+      "includeTypes",
+      "excludeTypes",
+      "includeSubtrees",
+      "includeEmptySubtrees",
+      "maxSubtreeDepth",
+      "maxSubtreeReports",
+    ],
+  };
+}
+
+function readCandidateReportOptions(input: CandidateReportBaseInput): CandidateReportOptions {
+  return {
+    parseOptions: { format: input.format },
+    maxResults: input.maxResults,
+    minScore: input.minScore,
+    includeTypes: input.includeTypes,
+    excludeTypes: input.excludeTypes,
+    includeNodes: input.includeNodes,
+    includeSubtrees: input.includeSubtrees,
+    includeEmptySubtrees: input.includeEmptySubtrees,
+    maxSubtreeDepth: input.maxSubtreeDepth,
+    maxSubtreeReports: input.maxSubtreeReports,
+  };
+}
+
+function readPkiCandidateReportOptions(input: PkiDefinitionSifterInput): PkiCandidateReportOptions {
+  return {
+    ...readCandidateReportOptions(input),
+    profiles: input.profiles,
+  };
+}
+
+function readDefinitionCorpus(input: DefinitionSifterInput): SchemaCorpus | undefined {
+  const definitions = [input.definition, ...(input.definitions ?? [])].filter((definition): definition is string => Boolean(definition));
+  if (definitions.length === 0) return undefined;
+  return parseAsn1DefinitionCorpus(definitions);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import { pathToFileURL } from "node:url";
 import { z } from "zod";
 
 import {
+  listAsn1DefinitionSifterFeatures,
+  siftAsn1DefinitionCandidates,
+  siftPkiAsn1DefinitionCandidates,
+} from "./asn1-defsifter.js";
+import {
   createAsn1Instance,
   listAsn1BuilderFeatures,
   parseAsn1DefinitionTool,
@@ -63,6 +68,7 @@ const optionalOutputEncodingSchema = z.enum(["hex", "base64"]).optional().descri
 const asn1BuilderSchemaModelSchema = z.record(z.string(), z.unknown()).optional().describe("ASN.1 Instance Builder Schema Model JSON. Provide this or definition.");
 const asn1BuilderDefinitionSchema = z.string().min(1).optional().describe("Supported ASN.1 definition subset text. Provide this or schema.");
 const asn1BuilderTypeNameSchema = z.string().min(1).describe("Defined ASN.1 type name to validate or build.");
+const asn1DefinitionSifterProfileSchema = z.enum(["components", "x509", "pkcs10", "pkcs8", "cms"]);
 const hashAlgorithmSchema = z.enum(["SHA-256", "SHA-384", "SHA-512"]).default("SHA-256").describe("Hash algorithm for signing.");
 const keyAlgorithmSchema = z.enum([
   "rsassa-pkcs1-v1_5-2048",
@@ -291,6 +297,63 @@ server.registerTool(
     inputSchema: {},
   },
   async () => jsonToolResult(listAsn1BuilderFeatures()),
+);
+
+server.registerTool(
+  "sift_asn1_definition_candidates",
+  {
+    title: "Sift ASN.1 Definition Candidates",
+    description: "Rank ASN.1 definition candidates for ASN.1 data using custom ASN.1 definitions or the built-in PKI component corpus.",
+    inputSchema: {
+      data: asn1InputSchema.data,
+      format: inputFormatSchema,
+      definition: z.string().min(1).optional().describe("Optional supported ASN.1 definition text for a custom corpus."),
+      definitions: z.array(z.string().min(1)).optional().describe("Optional supported ASN.1 definition texts for a custom corpus."),
+      maxResults: z.number().int().min(1).max(100).default(10),
+      minScore: z.number().min(0).max(1).optional().describe("Suppress candidates below this score."),
+      includeTypes: z.array(z.string().min(1)).optional().describe("Limit matching to local or qualified ASN.1 type names."),
+      excludeTypes: z.array(z.string().min(1)).optional().describe("Exclude local or qualified ASN.1 type names."),
+      includeNodes: z.boolean().default(false).describe("Include parsed TLV nodes in the report."),
+      includeSubtrees: z.boolean().default(false).describe("Include bounded candidate reports for child TLV nodes."),
+      includeEmptySubtrees: z.boolean().default(false).describe("Include subtree reports even when no candidates are found."),
+      maxSubtreeDepth: z.number().int().min(0).max(16).default(3),
+      maxSubtreeReports: z.number().int().min(1).max(200).default(20),
+    },
+  },
+  async (input) => jsonToolResult(await siftAsn1DefinitionCandidates(input)),
+);
+
+server.registerTool(
+  "sift_pki_asn1_definition_candidates",
+  {
+    title: "Sift PKI ASN.1 Definition Candidates",
+    description: "Rank PKI ASN.1 definition candidates using the built-in ASN.1 Definition Sifter PKI corpus and optional profile filters.",
+    inputSchema: {
+      data: asn1InputSchema.data,
+      format: inputFormatSchema,
+      profiles: z.array(asn1DefinitionSifterProfileSchema).optional().describe("Optional PKI profiles used to limit matching."),
+      maxResults: z.number().int().min(1).max(100).default(10),
+      minScore: z.number().min(0).max(1).optional().describe("Suppress candidates below this score."),
+      includeTypes: z.array(z.string().min(1)).optional().describe("Additional local or qualified ASN.1 type names to include."),
+      excludeTypes: z.array(z.string().min(1)).optional().describe("Exclude local or qualified ASN.1 type names."),
+      includeNodes: z.boolean().default(false).describe("Include parsed TLV nodes in the report."),
+      includeSubtrees: z.boolean().default(false).describe("Include bounded candidate reports for child TLV nodes."),
+      includeEmptySubtrees: z.boolean().default(false).describe("Include subtree reports even when no candidates are found."),
+      maxSubtreeDepth: z.number().int().min(0).max(16).default(3),
+      maxSubtreeReports: z.number().int().min(1).max(200).default(20),
+    },
+  },
+  async (input) => jsonToolResult(await siftPkiAsn1DefinitionCandidates(input)),
+);
+
+server.registerTool(
+  "list_asn1_definition_sifter_features",
+  {
+    title: "List ASN.1 Definition Sifter Features",
+    description: "List ASN.1 Definition Sifter tool scope, PKI profiles, and candidate report options.",
+    inputSchema: {},
+  },
+  async () => jsonToolResult(listAsn1DefinitionSifterFeatures()),
 );
 
 server.registerTool(


### PR DESCRIPTION
## Summary

- update PkiStudio runtime dependencies to the current compatible package set and add `@pkistudio/asn1defsifter`
- expose ASN.1 Definition Sifter reports through new MCP tools for generic/custom definitions and PKI profile matching
- document the updated package set and extend smoke coverage for definition sifter results

Closes #37

## Verification

- `npm run check`
- `npm run smoke`