### PR TITLE
Refresh PKI Studio family dependencies for 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,59 @@
 # PKI Studio MCP
 
-AI assistants can inspect certificates, keys, DER/PEM, OIDs, CSRs, and PKCS#12 files through MCP.
+PKI Studio MCP is a local MCP server for AI-assisted PKI, ASN.1, DER, PEM, X.509 certificate, CSR, key, and PKCS#12 workflows. It exposes PKI Studio family libraries as MCP tools for AI assistants through stdio and Streamable HTTP transports.
 
-`@pkistudio/pkistudiomcp` supports both stdio and Streamable HTTP transports. It exposes PKI Studio, CertGadgets, Private Key Gadgets, ASN.1 Instance Builder, and ASN.1 Definition Sifter capabilities as MCP tools.
+Documentation: https://github.com/pkistudio/pkistudiomcp/wiki
 
-## Quick Start: VS Code / GitHub Copilot
+Current version: 0.7.2
 
-Create `.vscode/mcp.json`:
+The server is designed for local assistant workflows first. Certificate parsing, ASN.1 parsing, key recognition, and PKCS#12 processing run inside the MCP server process. Network fetching is limited to the explicit `fetch_certificate_network_resources` tool.
+
+## Features
+
+- stdio MCP server for local VS Code, GitHub Copilot, Claude Desktop, and other MCP clients.
+- Streamable HTTP MCP server for local, containerized, or controlled remote deployments.
+- ASN.1 / DER / BER / PEM parsing, summaries, node extraction, and decoded node values.
+- OBJECT IDENTIFIER encoding, decoding, and name resolution through PkiStudioJS.
+- X.509 certificate parsing through CertGadgets, including CDP/AIA/OCSP resource plans without automatic network access.
+- PKCS#8 private key and SPKI public key recognition, key pair generation, key verification, certificate/key matching, CSR creation, and self-signed certificate creation through Private Key Gadgets.
+- PKCS#12 / PFX import and export helpers for certificate and key bundles.
+- ASN.1 Instance Builder tools for parsing supported ASN.1 definitions, validating schema/instance JSON, and building DER.
+- ASN.1 Definition Sifter tools for ranking likely ASN.1 type definitions for DER/TLV data.
+- MCP workflow prompts for certificate inspection, certificate/key comparison, and PKCS#12 analysis.
+- Docker image for the Streamable HTTP server.
+
+See the Wiki for details:
+
+- [Getting Started](https://github.com/pkistudio/pkistudiomcp/wiki/Getting-Started)
+- [MCP Client Configuration](https://github.com/pkistudio/pkistudiomcp/wiki/MCP-Client-Configuration)
+- [Tool Guide](https://github.com/pkistudio/pkistudiomcp/wiki/Tool-Guide)
+- [Security Notes](https://github.com/pkistudio/pkistudiomcp/wiki/Security-Notes)
+- [HTTP Deployment](https://github.com/pkistudio/pkistudiomcp/wiki/HTTP-Deployment)
+- [Testing](https://github.com/pkistudio/pkistudiomcp/wiki/Testing)
+- [Development](https://github.com/pkistudio/pkistudiomcp/wiki/Development)
+
+## Install
+
+Run the stdio MCP server from npm:
+
+```sh
+npx -y @pkistudio/pkistudiomcp
+```
+
+Run the Streamable HTTP MCP server from npm:
+
+```sh
+npx -y --package @pkistudio/pkistudiomcp pkistudiomcp-http
+```
+
+Package commands:
+
+- `pkistudiomcp`: stdio MCP server.
+- `pkistudiomcp-http`: Streamable HTTP MCP server.
+
+## MCP Client Quick Start
+
+VS Code / GitHub Copilot `.vscode/mcp.json`:
 
 ```json
 {
@@ -20,13 +67,7 @@ Create `.vscode/mcp.json`:
 }
 ```
 
-Then open Copilot Chat Agent mode and ask:
-
-> Parse this PEM certificate and summarize the issuer, subject, validity, extensions, and ASN.1 structure.
-
-## Quick Start: Claude Desktop
-
-Add this server to your Claude Desktop MCP configuration:
+Claude Desktop configuration:
 
 ```json
 {
@@ -39,27 +80,15 @@ Add this server to your Claude Desktop MCP configuration:
 }
 ```
 
-## Run Locally
+Example assistant prompts:
 
-Run the stdio MCP server from npm:
+- Parse this PEM certificate and summarize the issuer, subject, validity, extensions, and ASN.1 structure.
+- Show all OIDs found in this DER data and resolve their names.
+- Check whether this certificate matches this private key.
+- Read this PKCS#12 file and list contained certificates and keys.
+- Identify likely ASN.1 type definitions for this DER data.
 
-```sh
-npx -y @pkistudio/pkistudiomcp
-```
-
-Run the Streamable HTTP server from npm:
-
-```sh
-npx -y --package @pkistudio/pkistudiomcp pkistudiomcp-http
-```
-
-For a local checkout:
-
-```sh
-npm install
-npm run check
-npm start
-```
+For client-specific details, see [MCP Client Configuration](https://github.com/pkistudio/pkistudiomcp/wiki/MCP-Client-Configuration).
 
 ## Docker
 
@@ -74,38 +103,53 @@ The Docker image starts the Streamable HTTP server by default. The MCP endpoint 
 Pin a release version when reproducibility matters:
 
 ```sh
-docker run --rm -p 3000:3000 pkistudio/pkistudiomcp:0.7.1
+docker run --rm -p 3000:3000 pkistudio/pkistudiomcp:0.7.2
 ```
 
-## What Can I Ask?
+For HTTP deployment controls, see [HTTP Deployment](https://github.com/pkistudio/pkistudiomcp/wiki/HTTP-Deployment) and [Security Notes](https://github.com/pkistudio/pkistudiomcp/wiki/Security-Notes).
 
-- Parse this PEM certificate and summarize it.
-- Show all OIDs found in this DER data.
-- Check whether this certificate matches this private key.
-- Read this PKCS#12 file and list contained certificates and keys.
-- Generate a test key pair and CSR.
-- Identify likely ASN.1 type definitions for this DER data.
-- Build DER from this ASN.1 definition and JSON instance.
+## Development
 
-## Main Tool Areas
+Run local checks with:
 
-- Certificate inspection: `parse_certificate`, `parse_asn1`, `resolve_oid`
-- DER / ASN.1 inspection: `parse_asn1`, `summarize_asn1`, `describe_node`, `extract_asn1_node`, `asn1_node_value`
-- OID utilities: `encode_oid`, `decode_oid_value`, `resolve_oid`
-- Key material: `recognize_key_material`, `generate_key_pair`, `verify_key_pair`, `certificate_matches_key`
-- CSR and test certificates: `create_csr`, `create_self_signed_certificate`
-- PKCS#12 / PFX: `read_pkcs12`, `write_pkcs12`
-- ASN.1 Definition Sifter: `sift_asn1_definition_candidates`, `sift_pki_asn1_definition_candidates`
-- ASN.1 Instance Builder: `parse_asn1_definition`, `validate_asn1_schema`, `validate_asn1_instance`, `create_asn1_instance`
+```sh
+npm install
+npm run check
+npm run test
+```
 
-## Security Notes
+Run the stdio server locally:
 
-Certificate parsing, ASN.1 parsing, key recognition, and PKCS#12 processing are local operations inside the MCP server process. `fetch_certificate_network_resources` is different: it performs external HTTP(S) requests for CDP/AIA/OCSP-related resources discovered in certificates.
+```sh
+npm start
+```
 
-Do not send production private keys, sensitive PKCS#12 files, or private certificate material to public demo endpoints. Even when the server processes data locally, MCP clients and AI chat histories may retain input or output.
+Run the HTTP server locally:
 
-If you expose the HTTP server beyond localhost, place it behind authentication, request size limits, rate limits, timeouts, logging, and a restrictive CORS policy. The built-in HTTP server also supports optional `PKISTUDIOMCP_HTTP_BEARER_TOKEN`, `PKISTUDIOMCP_HTTP_CORS_ORIGIN`, `PKISTUDIOMCP_HTTP_MAX_CONTENT_LENGTH`, and `PKISTUDIOMCP_HTTP_REQUEST_TIMEOUT_MS` settings.
+```sh
+npm run start:http
+```
 
-## Documentation
+For package or release-related changes, also run:
 
-See the [GitHub Wiki](https://github.com/pkistudio/pkistudiomcp/wiki) for detailed usage, client configuration, tool selection guidance, security notes, Docker usage, deployment notes, release process, and troubleshooting.
+```sh
+npm pack --dry-run
+```
+
+For standard checks, MCP smoke coverage, package preview, local Wiki clone conventions, and release workflow notes, see [Testing](https://github.com/pkistudio/pkistudiomcp/wiki/Testing) and [Development](https://github.com/pkistudio/pkistudiomcp/wiki/Development).
+
+## PKI Studio Family Dependencies
+
+PKI Studio MCP imports the published PKI Studio family npm packages rather than vendoring their source:
+
+- `@pkistudio/pkistudiojs`
+- `@pkistudio/certgadgets`
+- `@pkistudio/pvkgadgets`
+- `@pkistudio/asn1instancebuilder`
+- `@pkistudio/asn1defsifter`
+
+Keep these dependencies aligned with the latest compatible PKI Studio family releases when updating MCP tool coverage or documentation.
+
+## License
+
+PKI Studio MCP is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pkistudio/pkistudiomcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@pkistudio/asn1defsifter": "^0.1.3",
-        "@pkistudio/asn1instancebuilder": "^0.1.2",
+        "@pkistudio/asn1defsifter": "^0.1.5",
+        "@pkistudio/asn1instancebuilder": "^0.1.13",
         "@pkistudio/certgadgets": "^0.1.4",
         "@pkistudio/pkistudiojs": "^0.6.1",
         "@pkistudio/pvkgadgets": "^0.4.2",
@@ -538,19 +538,19 @@
       }
     },
     "node_modules/@pkistudio/asn1defsifter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@pkistudio/asn1defsifter/-/asn1defsifter-0.1.3.tgz",
-      "integrity": "sha512-M3c5YmUCOaz//3CRCKJ7qYEHKANa0Dj9GcwQGkWgjE5n7qzRHy2D70cz1LGzwGdfMaEo9XqMy+ACkC/sesvkjA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@pkistudio/asn1defsifter/-/asn1defsifter-0.1.5.tgz",
+      "integrity": "sha512-Bp/XqZBTt6vTIlP96KUU54nQ05TN+UXBaWKKVUFBAXEBRrhGsO0lJnwx1poNl/zOmD9HhD0YGSD7EHOdHQuuEQ==",
       "license": "MIT",
       "dependencies": {
-        "@pkistudio/asn1instancebuilder": "^0.1.2",
+        "@pkistudio/asn1instancebuilder": "^0.1.3",
         "@pkistudio/pkistudiojs": "^0.6.1"
       }
     },
     "node_modules/@pkistudio/asn1instancebuilder": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@pkistudio/asn1instancebuilder/-/asn1instancebuilder-0.1.2.tgz",
-      "integrity": "sha512-yFpVwbIPJ1Szgtr7to1ezgJCaOvk1o0s6iXqm2hfxCpHudxKe4jDAlMWKn7oF8+wqUWOdoqcWWRY2/z7WGofFg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@pkistudio/asn1instancebuilder/-/asn1instancebuilder-0.1.13.tgz",
+      "integrity": "sha512-MpdhRdhxpH2seuIE6yiM/AR9RNCJOLcKA6fdzAwsG8efpgPu07GywgjmZ5g6GrIbhTYUZsYUGwHrSHLdmpnXnw==",
       "license": "MIT",
       "dependencies": {
         "@pkistudio/pkistudiojs": "^0.6.1"
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pkistudio/pkistudiomcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Local MCP server exposing PkiStudioJS ASN.1 and PKI key material tools.",
   "type": "module",
   "repository": {
@@ -46,8 +46,8 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@pkistudio/asn1defsifter": "^0.1.3",
-    "@pkistudio/asn1instancebuilder": "^0.1.2",
+    "@pkistudio/asn1defsifter": "^0.1.5",
+    "@pkistudio/asn1instancebuilder": "^0.1.13",
     "@pkistudio/certgadgets": "^0.1.4",
     "@pkistudio/pkistudiojs": "^0.6.1",
     "@pkistudio/pvkgadgets": "^0.4.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ const certificateNetworkResourceKindSchema = z.enum(["ocsp", "ca-issuers", "crl"
 export function createPkiStudioMcpServer(): McpServer {
   const server = new McpServer({
     name: "@pkistudio/pkistudiomcp",
-    version: "0.7.1",
+    version: "0.7.2",
   });
 
 registerPkiStudioPrompts(server);


### PR DESCRIPTION
Summary:
- Update PKI Studio family dependencies: `@pkistudio/asn1defsifter` to `^0.1.5` and `@pkistudio/asn1instancebuilder` to `^0.1.13`.
- Apply npm audit fix for the transitive `qs` advisory.
- Bump package metadata and MCP server metadata to 0.7.2.
- Refresh README to match the PKI Studio family documentation style, without adding screenshots.

Wiki:
- Updated the GitHub Wiki separately with current version and dependency guidance.
- Added a Testing page and linked it from the sidebar.

Release notes draft:
- Update ASN.1 Definition Sifter and ASN.1 Instance Builder dependencies.
- Refresh README and Wiki documentation structure to match the PKI Studio family style.
- Resolve the current production npm audit advisory.

Verification:
- `npm audit --omit=dev`
- `npm run test`
- `npm pack --dry-run`

Fixes #42